### PR TITLE
Add TravisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+
+node_js:
+  - node
+
+os:
+  - linux
+  - osx
+
+script:
+  - npm run setup
+  - figmagic
+  - \[ -d figma \]
+  - \[ -f figma/figma.json \]
+  - \[ -d tokens \]
+  - \[ -f tokens/colors.mjs \]
+
+notifications:
+  email: false

--- a/index.mjs
+++ b/index.mjs
@@ -1,5 +1,5 @@
 #!/bin/sh
-":"; //#; exec /usr/bin/env node --experimental-modules --no-warnings "$0" "$@"
+":"; //# ; exec /usr/bin/env node --experimental-modules --no-warnings "$0" "$@"
 
 import { createFolder } from "./bin/functions/createFolder.mjs";
 import { getFromApi } from "./bin/functions/getFromApi.mjs";

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # Figmagic
+[![Build Status](https://travis-ci.org/mikaelvesavuori/figmagic.svg?branch=master)](https://travis-ci.org/mikaelvesavuori/figmagic)
 
 Automate the generation of design tokens and specs from your Figma documents. Inspired by [Salesforce Theo](https://github.com/salesforce-ux/theo).
 


### PR DESCRIPTION
Fixes issue #3.

This adds a simple sanity check to make sure the `figmagic` command runs successfully on Linux and Mac, as you can see [here](https://travis-ci.org/vspedr/figmagic/builds/499936387). It checks if the `figma` and `tokens` directories and at least `figma/figma.json` and `tokens/colors.mjs` were created.

After merging this PR you will need to create a travis-ci.org free account (if you don't have one already), activate the figmagic repo and add the `FIGMA_TOKEN` and `FIGMA_URL` variables in the build settings. This shouldn't take more than 5 minutes.

Also you get a nice badge in your README displaying the status of the last build on `master` ;)

Feel free to contact me if you have any questions!