### PR TITLE
Ignore elements by adding keywords to the element name

### DIFF
--- a/bin/functions/process/processTokens.mjs
+++ b/bin/functions/process/processTokens.mjs
@@ -14,6 +14,7 @@ import { setupOpacitiesTokens } from '../tokens/setupOpacitiesTokens.mjs';
 import { setupDurationTokens } from '../tokens/setupDurationTokens.mjs';
 
 import { errorProcessTokens, errorProcessTokensNoConfig } from '../../meta/errors.mjs';
+import { ignoreElementsKeywords } from '../../meta/ignoreElementsKeywords.mjs';
 
 /**
  * Process tokens
@@ -29,6 +30,22 @@ import { errorProcessTokens, errorProcessTokensNoConfig } from '../../meta/error
  */
 export function processTokens(sheet, name, config) {
   if (!sheet || !name) throw new Error(errorProcessTokens);
+
+  // Filter out elements that contain ignore keywords in their name
+  sheet.children = sheet.children.filter((item) => {
+    let shouldInclude = true;
+
+    for (let i = 0; i < ignoreElementsKeywords.length; i++) {
+      const keywordToIgnore = ignoreElementsKeywords[i];
+
+      if (item.name.toLowerCase().indexOf(keywordToIgnore) >= 0) {
+        shouldInclude = false;
+        break;
+      }
+    }
+
+    return shouldInclude;
+  });
 
   const _NAME = name.toLowerCase();
   let processedTokens = undefined;

--- a/bin/meta/ignoreElementsKeywords.mjs
+++ b/bin/meta/ignoreElementsKeywords.mjs
@@ -1,0 +1,1 @@
+export const ignoreElementsKeywords = ['ignore'];

--- a/testdata/durationsFrame.mjs
+++ b/testdata/durationsFrame.mjs
@@ -43,6 +43,25 @@ export const durationsFrame = {
       styleOverrideTable: {}
     },
     {
+      id: '2657:100',
+      name: 'Ignore - Helper text only',
+      type: 'TEXT',
+      blendMode: 'PASS_THROUGH',
+      absoluteBoundingBox: [Object],
+      constraints: [Object],
+      fills: [Array],
+      strokes: [],
+      strokeWeight: 1,
+      strokeAlign: 'OUTSIDE',
+      exportSettings: [Array],
+      effects: [],
+      characters: 'Example text',
+      style: [Object],
+      layoutVersion: 1,
+      characterStyleOverrides: [],
+      styleOverrideTable: {}
+    },
+    {
       id: '2657:101',
       name: 'Medium',
       type: 'TEXT',


### PR DESCRIPTION
Closes #30

I added a filter in `processTokens` to centralize it.

For now the only keyword to ignore elements is `"ignore"` but I used an array of keywords, so it is easy to add more:
https://github.com/Stanko/figmagic/blob/ignore/bin/meta/ignoreElementsKeywords.mjs

EDIT: It might be useful to allow users to configure it.