### PR TITLE
Fixed camelize function and added more test cases

### DIFF
--- a/__tests__/camelize.test.mjs
+++ b/__tests__/camelize.test.mjs
@@ -8,12 +8,32 @@ test('It should lower-case the string', () => {
   expect(camelize('ASDF')).toBe('asdf');
 });
 
-test('It should trim trailing whitespace', () => {
-  expect(camelize('text       ')).toBe('text');
+test('It should trim whitespace', () => {
+  expect(camelize('     text       ')).toBe('text');
 });
 
 test('It should throw an error if no parameter is provided', () => {
   expect(() => {
     camelize();
   }).toThrow();
+});
+
+test('It should not change already camelcased word', () => {
+  expect(camelize('camelCaseWord')).toBe('camelCaseWord');
+});
+
+test('It should convert snake case', () => {
+  expect(camelize('snake_case_word')).toBe('snakeCaseWord');
+});
+
+test('It should convert kebab case', () => {
+  expect(camelize('kebab-case-word')).toBe('kebabCaseWord');
+});
+
+test('It should consider mutiple spaces as a single space', () => {
+  expect(camelize('hello               world')).toBe('helloWorld');
+});
+
+test('It should consider all characters that are not letter nor digit as a space', () => {
+  expect(camelize('hello }[";-_world')).toBe('helloWorld');
 });

--- a/bin/functions/helpers/camelize.mjs
+++ b/bin/functions/helpers/camelize.mjs
@@ -12,12 +12,27 @@ import { errorCamelize } from '../../meta/errors.mjs';
 export function camelize(str) {
   if (!str) throw new Error(errorCamelize);
 
-  return str
-    .toLowerCase()
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
-      return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
-    })
-    .replace(/\\/g, '-')
-    .replace(/\//g, '-')
-    .replace(/\s+/g, '');
+  return (
+    str
+      // Add a space after uppercase words
+      .replace(/[A-Z]+/g, function (word, index) {
+        return ' ' + word;
+      })
+      // Replace all characters that are not letter or number with a space
+      .replace(/[^a-zA-Z0-9]+/g, ' ')
+      // Remove leading and trailing spaces
+      .trim()
+      // Find all words, and capitalize the first letter
+      // and lowercase the rest of the word.
+      // Except the first word which is fully lowercased.
+      .replace(/[a-zA-Z0-9]+/g, function (word, index) {
+        if (index === 0) {
+          return word.toLowerCase();
+        }
+
+        return word[0].toUpperCase() + word.slice(1).toLowerCase();
+      })
+      // Finally remove all remaining spaces
+      .replace(/ /g, '')
+  );
 }


### PR DESCRIPTION
Hey, I'm working on adding easing and delays token types, and I noticed that `camelize` function is acting weirdly - sometimes dashes would slip and already camel cased words were converted to lower case. ATM `formatName` [is replacing](https://github.com/mikaelvesavuori/figmagic/blob/master/bin/functions/helpers/formatName.mjs#L19) only the first appearance of the forbidden characters.

I wrote a slightly different version of `camelized` and this one makes `formatName` obsolete, so if you agree with this approach I will remove `formatName` completely before you merge this one.
