### PR TITLE
Remove docs command from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,5 +6,4 @@ npm run clean
 npm run licenses
 npm run lint
 npm run build
-npm run docs
 git add .


### PR DESCRIPTION
Hey,

When attempting to commit I noticed it runs `npm run docs`, but I also noticed that it changes the `href` path of all links to the forked repository instead of keeping with the upstream branch.

![image](https://user-images.githubusercontent.com/19270322/136826300-dd94038a-7c59-45a1-bf27-d3858dbda9ad.png)

I also tried to update `typedoc.json` to add 

```
"gitRemote": "upstream"
```

or 

```
"gitRemote": "https://github.com/mikaelvesavuori/figmagic.git"
```

as suggested in the [docs](https://typedoc.org/guides/options/#gitremote), but then it removes the link to the upstream branch, keeping only the text:

![image](https://user-images.githubusercontent.com/19270322/136836506-49e37a59-2a12-4bac-8e49-3d870fc10b5a.png)

So, if we still want the links to the files, I think we can remove the docs generation as a `pre-commit` `hook`, and let the maintainer generate. Another option is to edit `typedoc.json` to add `gitRemote` and lose the links in favour of improving maintenance.