### PR TITLE
refactored getTokenEnumString and getTokenString functions into single one

### DIFF
--- a/bin/frameworks/filesystem/getFileContentAndPath.ts
+++ b/bin/frameworks/filesystem/getFileContentAndPath.ts
@@ -67,7 +67,7 @@ export function getFileContentAndPath(
       },
       token: () => {
         if (metadata && metadata.dataType === 'enum')
-          return { fileContent: getTokenEnumString(file, name, format), filePath };
+          return { fileContent: getTokenString(file, name, format, metadata.dataType), filePath };
 
         filePath += `.${format}`;
         return { fileContent: getTokenString(file, name, format), filePath };
@@ -119,23 +119,26 @@ export function getFileContentAndPath(
 }
 
 /**
- * @description Get file data string for tokens using enum data type
+ * @description Get file data string for tokens using either null/no data type or enum data type
  */
-const getTokenEnumString = (file: string | ProcessedToken, name: string, format: string) => {
-  const EXPORT = format === 'js' ? `module.exports = ${name}` : `export default ${name}`;
-  return `// ${MsgGeneratedFileWarning}\n\nenum ${name} {${createEnumStringOutOfObject(
-    file
-  )}\n}\n\n${EXPORT};`;
-};
-
-/**
- * @description Get file data string for tokens using null/no data type
- */
-const getTokenString = (file: string | ProcessedToken, name: string, format: string) => {
+const getTokenString = (
+  file: string | ProcessedToken,
+  name: string,
+  format: string,
+  dataType?: string
+) => {
   if (format === 'json') return `${JSON.stringify(file, null, ' ')}`;
 
   const EXPORT = format === 'js' ? `module.exports = ${name}` : `export default ${name}`;
+
+  if (dataType === 'enum') {
+    return `// ${MsgGeneratedFileWarning}\n\nenum ${name} {${createEnumStringOutOfObject(
+      file
+    )}\n}\n\n${EXPORT};`;
+  }
+
   const CONST_ASSERTION = format === 'ts' ? ' as const;' : '';
+
   return `// ${MsgGeneratedFileWarning}\n\nconst ${name} = ${JSON.stringify(
     file,
     null,


### PR DESCRIPTION
 - [X] I have read the figmagic Contribution Guideline 
 - [X] The PR title summarizes the change
 
#### 1. Description of the changes made:

Refactored `getTokenEnumString` and `getTokenString` to be a single function of `getTokenString` and ensured that the current tests that utilizes the `getFileContentAndPath` function still all pass.

Screenshot of the individual test passing is below:

<img width="540" alt="Screen Shot 2021-10-12 at 1 18 50 PM" src="https://user-images.githubusercontent.com/64395142/136910277-83501923-c6cc-4a68-9169-e92267e484c8.png">


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number\

closes #131 
