### PR TITLE
Adding test:watch npm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clean": "rm -rf .figmagic-trash/",
     "build": "rm -rf build && npx webpack",
     "test": "jest __tests__ --collectCoverage --runInBand",
+    "test:watch": "jest --clearCache && jest __tests__ --collectCoverage --runInBand --watch",
     "lint": "npx eslint './bin/**/*.ts' --quiet --fix",
     "docs": "npx typedoc && npx arkit",
     "licenses": "npx license-compliance --direct --allow 'MIT;ISC;0BSD;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Unlicense;CC0-1.0'",


### PR DESCRIPTION
- [x] I have read the Figmagic Contribution Guideline
- [x] The PR title summarizes the change

**1. Description of the changes made:**


- Added `test:watch` npm script command into `package.json`, so developers can take advantage of the [Jest watch mode](https://jestjs.io/docs/cli#--watch) to run tests, like filtering by pattern match and watching for file changes

**2. Screenshots**

Watch mode (`npm run test:watch`):

![image](https://user-images.githubusercontent.com/19270322/138935780-5a450a39-b679-4579-8e2e-78665f0940d8.png)